### PR TITLE
add redirect to updated CC website

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,14 +2,14 @@
 <html lang="en-US">
     <head>
         <meta charset="UTF-8">
-        <meta http-equiv="refresh" content="0; url=https://cc-conference.github.io/20/">
+        <meta http-equiv="refresh" content="0; url=https://conf.researchr.org/series/CC/">
         <script type="text/javascript">
-            window.location.href = "https://cc-conference.github.io/20/"
+            window.location.href = "https://conf.researchr.org/series/CC/"
         </script>
         <title>Page Redirection</title>
     </head>
     <body>
         <!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
-        If you are not redirected automatically, follow this <a href='https://cc-conference.github.io/20/'>link to the website of the International Conference on Compiler Construction 2020</a>.
+        If you are not redirected automatically, follow this <a href='https://conf.researchr.org/series/CC/'>link to the website of the International Conference on Compiler Construction</a>.
     </body>
 </html>


### PR DESCRIPTION
The updated redirect will always lead to the current CC website. It will not have to be updated for the next conferences.